### PR TITLE
Added a break after having a candidate AA.

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -411,7 +411,7 @@ extern "C" void RADIO_IRQHandler(void)
               }
               else
               {
-                /* Shit right by one bit once and twice */
+                /* Shift right by one bit once and twice */
                 for (j=0; j<2; j++)
                 {
                   /* Shift right. */
@@ -430,6 +430,7 @@ extern "C" void RADIO_IRQHandler(void)
                       if (seen_aa(aa) > 1) {
                           /* We may have a candidate AA. */
                           pLink->notifyAccessAddress(aa, g_sniffer.channel, NRF_RADIO->RSSISAMPLE);
+                          break;
                       }
                   }
                 }


### PR DESCRIPTION
* After getting a candidate AA from `rx_buffer` in `SNIFF_AA` mode, we can break the loop which shifts `rx_buffer` right by one bit once and twice.
* Corrected comments of the loop, shit -> shift.