### PR TITLE
Updated lower limit of 'inter' when recovering hop interval.

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -569,7 +569,7 @@ extern "C" void RADIO_IRQHandler(void)
                       /* compute interval based on measures. */
                       curtime = measures;
                       inter = (curtime - g_sniffer.prev_time);
-                      if (inter > 2)
+                      if (inter > 216)
                       {
                           g_sniffer.prev_time = curtime;
                           if ((inter/37) != (g_sniffer.observed_interval/37))


### PR DESCRIPTION
We expect a complete hop sequence cycle when recovering the hop interval. So the `inter` should be greater than `(HOPSEQ_PERIOD - 1) * MIN_HOPINTER) = 216`, which `HOPSEQ_PERIOD` is 37 and `MIN_HOPINTER` is `7.5 ms / 1.25 ms = 6`.

In any case I would like to hear your opinions. :blush: