### PR TITLE
Maybe bug fix: TASKS_START might be invoked head of time

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -382,11 +382,6 @@ extern "C" void RADIO_IRQHandler(void)
     uint8_t candidate_pdu[2];
     int i,j;
 
-    if (NRF_RADIO->EVENTS_READY) {
-        NRF_RADIO->EVENTS_READY = 0;
-        NRF_RADIO->TASKS_START = 1;
-    }
-
     if (NRF_RADIO->EVENTS_END) {
         NRF_RADIO->EVENTS_END = 0;
 
@@ -1287,8 +1282,12 @@ static void sync_lost_track(void)
 
     // enable receiver (once enabled, it will listen)
     NRF_RADIO->EVENTS_READY = 0;
-    NRF_RADIO->EVENTS_END = 0;
     NRF_RADIO->TASKS_RXEN = 1;
+    while (NRF_RADIO->EVENTS_READY == 0);
+  
+    NRF_RADIO->EVENTS_END = 0;
+    NRF_RADIO->TASKS_START = 1;
+
   }
 
 #if 0
@@ -1375,8 +1374,11 @@ static void sync_hop_channel(void)
 
   // enable receiver (once enabled, it will listen)
   NRF_RADIO->EVENTS_READY = 0;
-  NRF_RADIO->EVENTS_END = 0;
   NRF_RADIO->TASKS_RXEN = 1;
+  while (NRF_RADIO->EVENTS_READY == 0);
+
+  NRF_RADIO->EVENTS_END = 0;
+  NRF_RADIO->TASKS_START = 1;
 }
 
 

--- a/source/radio.cpp
+++ b/source/radio.cpp
@@ -300,8 +300,11 @@ void radio_follow_conn(uint32_t accessAddress, int channel, uint32_t crcInit)
 
     // enable receiver (once enabled, it will listen)
     NRF_RADIO->EVENTS_READY = 0;
-    NRF_RADIO->EVENTS_END = 0;
     NRF_RADIO->TASKS_RXEN = 1;
+    while (NRF_RADIO->EVENTS_READY == 0);
+
+    NRF_RADIO->EVENTS_END = 0;
+    NRF_RADIO->TASKS_START = 1;
 }
 
 void radio_set_channel_fast(int channel)
@@ -323,8 +326,11 @@ void radio_set_channel_fast(int channel)
 
   // enable receiver (once enabled, it will listen)
   NRF_RADIO->EVENTS_READY = 0;
-  NRF_RADIO->EVENTS_END = 0;
   NRF_RADIO->TASKS_RXEN = 1;
+  while (NRF_RADIO->EVENTS_READY == 0);
+
+  NRF_RADIO->EVENTS_END = 0;
+  NRF_RADIO->TASKS_START = 1;
 }
 
 /**
@@ -358,8 +364,11 @@ void radio_send(uint8_t *pBuffer, int size)
   NRF_RADIO->SHORTS = RADIO_SHORTS_READY_START_Msk/* | RADIO_SHORTS_END_DISABLE_Msk*/;
 
   NRF_RADIO->EVENTS_READY = 0;
-  NRF_RADIO->EVENTS_END = 0;
   NRF_RADIO->TASKS_TXEN = 1;
+  while (NRF_RADIO->EVENTS_READY == 0);
+
+  NRF_RADIO->EVENTS_END = 0;
+  NRF_RADIO->TASKS_START = 1;
 
   /* From now, radio will send data and notify the result to Radio_IRQHandler */
 }
@@ -413,8 +422,11 @@ void radio_send_rx(uint8_t *pBuffer, int size, int channel)
   NRF_RADIO->SHORTS = RADIO_SHORTS_READY_START_Msk | RADIO_SHORTS_END_DISABLE_Msk  | RADIO_SHORTS_DISABLED_RXEN_Msk;
 
   NRF_RADIO->EVENTS_READY = 0;
-  NRF_RADIO->EVENTS_END = 0;
   NRF_RADIO->TASKS_TXEN = 1;
+  while (NRF_RADIO->EVENTS_READY == 0);
+
+  NRF_RADIO->EVENTS_END = 0;
+  NRF_RADIO->TASKS_START = 1;
 
   /* From now, radio will send data and notify the result to Radio_IRQHandler */
 }
@@ -440,6 +452,9 @@ void radio_anchor_receive(void)
   NRF_RADIO->SHORTS = RADIO_SHORTS_READY_START_Msk | RADIO_SHORTS_END_DISABLE_Msk | RADIO_SHORTS_DISABLED_TXEN_Msk;
 
   NRF_RADIO->EVENTS_READY = 0;
-  NRF_RADIO->EVENTS_END = 0;
   NRF_RADIO->TASKS_RXEN = 1;
+  while (NRF_RADIO->EVENTS_READY == 0);
+
+  NRF_RADIO->EVENTS_END = 0;
+  NRF_RADIO->TASKS_START = 1;
 }


### PR DESCRIPTION
I don't have full confidence in this patch. I have not tested all functionalities, but it seems to work pretty well.

Problem:
I was trying to capture all packets including zero length packets which are normally not sent. So I modified the firmware, and I noticed that I was getting a lot of corrupt packets.
An easy way to manifest the corruption bug is to invoke the call to pLink->notifyNordicTapBlePacket() in main.cpp:838 twice. Normally, one should see the same packets twice coming when sniffing new connections with `btlejack -c any -v`. Oddly, we see many packets that are corrupted.

In turns out, the radio DMA controller overwrites the rx_buffer as we are copying it in `notifyNordicTapBlePacket()` . This should not happen as we do not trigger a `NRF_RADIO->TASKS_START = 1` until after the UART has copied the bytes.

So it turned out, after `while (NRF_RADIO->EVENTS_READY == 0);` in `radio_set_sniff()`, we set `NRF_RADIO->TASKS_START = 1`, without reseting the `NRF_RADIO->EVENTS_READY` flag to 0. Eventually, the END event triggers and we land in the interrupt routine `RADIO_IRQHandler()`. But because we didn't put the `NRF_RADIO->EVENTS_READY` flag to 0 earlier, we test it to 1 and so we set `TASKS_START = 1`, which is problematic because now the receiver is allowed to overwrite the `rx_buffer` while we are using it.

Normally, this should only corrupt the first packet. However, I saw endless corrupted packets. So I am not confident that this is the right explanation. And so I'm not confident that this is the right fix.

The IRQ handler is set to only trigger on END events, not READY events. So we can only get into the IRQ handler by having been ready in the first place. I am quite confused. Maybe someone can shed some light on this.